### PR TITLE
Allow to pre-download Renode

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -7,12 +7,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Run sample test
+
+      - name: Download Renode
         uses: ./
-        with:
-           tests-to-run:  __tests__/hello_world.robot
 
       - name: Verify if Renode is persistent
         run: src/check_renode_install.sh || exit 1
         shell: bash
 
+      - name: Run sample test
+        uses: ./
+        with:
+           tests-to-run:  __tests__/hello_world.robot

--- a/README.md
+++ b/README.md
@@ -11,8 +11,58 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: antmicro/renode-test-action@v1.0.0
+- uses: antmicro/renode-test-action@v2.0.0
   with:
     renode-version: 'latest'
-    tests-to-run: 'tests/**/*.robot' 
+    tests-to-run: 'tests/**/*.robot'
+```
+
+## Using cache
+
+If you use this action many times in a single job, Renode gets downloaded only once.
+
+However, if you want to use the same Renode instance across multiple jobs, it's advisable to use cache.
+
+```yaml
+jobs:
+  first-job:
+    steps:
+     - name: Prepare Renode settings
+       run: |
+         echo "RENODE_VERSION=latest" >> $GITHUB_ENV
+         echo "RENODE_DIR=/some/directory" >> $GITHUB_ENV
+
+     - name: Download Renode
+       uses: antmicro/renode-test-action@v2.0.0
+       with:
+        renode-version: '${{ env.RENODE_VERSION }}'
+        renode-path: '${{ env.RENODE_DIR }}'
+
+     - name: Cache Renode installation
+       uses: actions/cache@v2
+       id: cache-renode
+       with:
+         path: '${{ env.RENODE_DIR }}'
+         key: cache-renode-${{ env.RENODE_VERSION }}
+
+  second-job:
+    steps:
+     - name: Prepare Renode settings
+       run: |
+         echo "RENODE_VERSION=latest" >> $GITHUB_ENV
+         echo "RENODE_DIR=/some/directory" >> $GITHUB_ENV
+
+     - name: Restore Renode
+       uses: actions/cache@v2
+       id: cache-renode
+       with:
+         path: '${{ env.RENODE_DIR }}'
+         key: cfu-cache-renode-${{ env.RENODE_VERSION }}
+
+     - name: Run tests
+       uses: antmicro/renode-test-action@v2.0.0
+       with:
+         renode-version: '${{ env.RENODE_VERSION }}'
+         tests-to-run: tests-*.robot
+         renode-path: '${{ env.RENODE_DIR }}'
 ```

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Robot framework test paths'
     required: true
     default: 'tests/**/*.robot'
+  renode-path:
+    description: 'Path for Renode installation. May be used to cache Renode between jobs'
+    required: false
+    default: '${{ runner.temp }}/renode'
 runs:
   using: "composite"
   steps:
@@ -23,3 +27,4 @@ runs:
       env:
         RENODE_VERSION: ${{ inputs.renode-version }}
         TESTS_TO_RUN: ${{ inputs.tests-to-run }}
+        RENODE_DIR: ${{ inputs.renode-path }}

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,7 @@ inputs:
     default: 'latest'
   tests-to-run:
     description: 'Robot framework test paths'
-    required: true
-    default: 'tests/**/*.robot'
+    required: false
   renode-path:
     description: 'Path for Renode installation. May be used to cache Renode between jobs'
     required: false

--- a/src/run_renode_test.sh
+++ b/src/run_renode_test.sh
@@ -31,6 +31,11 @@ fi
 
 echo "::add-matcher::$MATCHER_PATH/renode-problem-matcher.json"
 
-$RENODE_DIR/test.sh $TESTS_TO_RUN
+if [ -z "$TESTS_TO_RUN" ]
+then
+    echo "No tests provided, Renode is installed to $RENODE_DIR"
+else
+    $RENODE_DIR/test.sh $TESTS_TO_RUN
+fi
 
 echo "::remove-matcher owner=test-in-renode::"

--- a/src/run_renode_test.sh
+++ b/src/run_renode_test.sh
@@ -3,7 +3,8 @@
 set -e
 if ! $GITHUB_ACTION_PATH/src/check_renode_install.sh;
 then
-    export RENODE_DIR=$(mktemp -d)
+    # RENODE_DIR should be set by the action parameter
+    mkdir -p $RENODE_DIR
     echo "RENODE_DIR=$RENODE_DIR" >> $GITHUB_ENV
     if ! wget -q https://dl.antmicro.com/projects/renode/builds/renode-$RENODE_VERSION.linux-portable.tar.gz;
     then

--- a/src/run_renode_test.sh
+++ b/src/run_renode_test.sh
@@ -6,7 +6,7 @@ then
     # RENODE_DIR should be set by the action parameter
     mkdir -p $RENODE_DIR
     echo "RENODE_DIR=$RENODE_DIR" >> $GITHUB_ENV
-    if ! wget -q https://dl.antmicro.com/projects/renode/builds/renode-$RENODE_VERSION.linux-portable.tar.gz;
+    if ! wget --progress=dot:giga https://dl.antmicro.com/projects/renode/builds/renode-$RENODE_VERSION.linux-portable.tar.gz;
     then
         echo "There was an error when downloading the package. The provided Renode version might be wrong: $RENODE_VERSION"
         exit 1

--- a/src/run_renode_test.sh
+++ b/src/run_renode_test.sh
@@ -12,13 +12,18 @@ then
         exit 1
     fi
     tar -xzf renode-$RENODE_VERSION.linux-portable.tar.gz -C $RENODE_DIR --strip 1
-    pip install -q -r $RENODE_DIR/tests/requirements.txt --no-warn-script-location
     if ! $GITHUB_ACTION_PATH/src/check_renode_install.sh;
     then
         echo "Tried to install Renode, but failed. Please inspect the log"
         exit 1
     fi
 fi
+
+# Install PIP requirements unconditionally.
+# This is usable if Renode comes from a GH Action cache - users
+# can cache RENODE_DIR to pass it between jobs, but Python dependencies
+# are a bit more difficult to locate and cache.
+pip install -q -r $RENODE_DIR/tests/requirements.txt --no-warn-script-location
 
 # path to a problem matcher file needs
 # to be accessible to the runner outside the container


### PR DESCRIPTION
This PR does several things:

- allow to provide path to predownloaded Renode
- allow to use this action just to download Renode, without running tests
- small cleanup and test update