### PR TITLE
Add renode-resources for renode-test

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Renode git repository'
     required: true
     default: 'https://github.com/renode/renode'
+  renode-resource-repository:
+    description: 'Renode binary resources git repository'
+    required: true
+    default: 'https://github.com/renode/renode-resources'
   tests-to-run:
     description: 'Robot framework test paths'
     required: false
@@ -42,9 +46,10 @@ runs:
         action_hash_key=0
         echo "renode-rev=$rev" >> "$GITHUB_OUTPUT"
         echo "action-hash-key=$action_hash_key" >> "$GITHUB_OUTPUT"
+        git clone "${{ inputs.renode-resource-repository }}" renode/lib/resources
         mv renode "renode-$rev-cloned"
       shell: bash
-      working-directory: ${{ runner.temp }}
+      working-directory: ${{ github.workspace }}
       # Avoid the download/build steps if Renode is already installed. We can't just put all of the build steps
       # into a nested composite action as it wouldn't be available when using this action from another repository.
       # See https://github.com/orgs/community/discussions/66094
@@ -52,14 +57,14 @@ runs:
     - uses: actions/cache/restore@v4
       id: restore-cache
       with:
-        path: ${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
+        path: ${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
         key: renode-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-renode-rev.outputs.renode-rev }}-${{ steps.get-renode-rev.outputs.action-hash-key }}
       if: ${{ env.RENODE_ROOT == '' }}
     # Remove the just-cloned source if a cached build was found
     - run: |
         rm -rf renode-${{ steps.get-renode-rev.outputs.renode-rev }}-cloned
       shell: bash
-      working-directory: ${{ runner.temp }}
+      working-directory: ${{ github.workspace }}
       if: ${{ env.RENODE_ROOT == '' && steps.restore-cache.outputs.cache-hit == 'true' }}
     - run: |
         mv renode-${{ steps.get-renode-rev.outputs.renode-rev }}-cloned renode-${{ steps.get-renode-rev.outputs.renode-rev }}
@@ -67,7 +72,7 @@ runs:
         echo Building "${{ inputs.renode-repository }}" at "${{ inputs.renode-revision }} (${{ steps.get-renode-rev.outputs.renode-rev }})"
         git submodule update --init --recursive --depth=1
       shell: bash
-      working-directory: ${{ runner.temp }}
+      working-directory: ${{ github.workspace }}
       if: ${{ env.RENODE_ROOT == '' && steps.restore-cache.outputs.cache-hit != 'true' }}
     - name: Install dependencies (Linux)
       run: |
@@ -79,7 +84,7 @@ runs:
       run: |
         ./build.sh
       shell: bash
-      working-directory: ${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
+      working-directory: ${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
       if: ${{ env.RENODE_ROOT == '' && runner.os != 'Windows' && steps.restore-cache.outputs.cache-hit != 'true' }}
     - name: Build Renode (Windows)
       run: |
@@ -89,34 +94,34 @@ runs:
         ./build.sh
         cp $GITHUB_ACTION_PATH/src/renode_test_windows.sh renode-test
       shell: bash
-      working-directory: ${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
+      working-directory: ${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
       if: ${{ env.RENODE_ROOT == '' && runner.os == 'Windows' && steps.restore-cache.outputs.cache-hit != 'true' }}
     - name: Delete files to slim down cache
       run: |
         find . -name .git -exec rm -rf '{}' '+'
         find lib src '(' -name bin -or -name obj ')' -exec rm -rf '{}' '+'
       shell: bash
-      working-directory: ${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
+      working-directory: ${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
       if: ${{ env.RENODE_ROOT == '' && steps.restore-cache.outputs.cache-hit != 'true' }}
     - uses: actions/cache/save@v4
       with:
-        path: ${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
+        path: ${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
         key: renode-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-renode-rev.outputs.renode-rev }}-${{ steps.get-renode-rev.outputs.action-hash-key }}
       if: ${{ env.RENODE_ROOT == '' && steps.restore-cache.outputs.cache-hit != 'true' }}
     - name: Install Robot framework dependencies
       run: python3 -m pip install -r tests/requirements.txt
       shell: bash
-      working-directory: ${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
+      working-directory: ${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
       if: ${{ env.RENODE_ROOT == '' }}
     - name: Install Robot framework dependencies under py on Windows
       run: py -3 -m pip install -r tests/requirements.txt
       shell: bash
-      working-directory: ${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
+      working-directory: ${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}
       if: ${{ env.RENODE_ROOT == '' && runner.os == 'Windows' }}
     - name: Setup environment
       run: |
-        echo "${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}" >> "$GITHUB_PATH"
-        echo "RENODE_ROOT=${{ runner.temp }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}" >> "$GITHUB_ENV"
+        echo "${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}" >> "$GITHUB_PATH"
+        echo "RENODE_ROOT=${{ github.workspace }}/renode-${{ steps.get-renode-rev.outputs.renode-rev }}" >> "$GITHUB_ENV"
       shell: bash
       if: ${{ env.RENODE_ROOT == '' }}
     - run: $GITHUB_ACTION_PATH/src/run_renode_test.sh


### PR DESCRIPTION
## Summary
Using the `renode-test-action` to run GitHub Actions fails because the `robot.css` file is missing. To address this issue, I added the action code to clone [renode-resources](https://github.com/renode/renode-resources) repository.

## Reproduction
You can reproduce this issue using the following files. I use [act](https://github.com/nektos/act) to run actions locally.
```
/example
  ├── .github/workflows
  │   └── action.yml
  └── test.robot
```

```action.yml
name: Example Action

on:
  pull_request:
    branches: [ $default-branch ]

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Install Packages
        run: |
          sudo apt-get update
          sudo apt-get install -y cmake

      - name: Execute Renode Test
        uses: renode-test-action@v4
        with:
          renode-revision: 'master'
          tests-to-run: 'test.robot'
          renode-arguments: '--css-file ../lib/resources/styles/robot.css'
```

```test.robot
*** Settings ***
Suite Setup     Setup
Suite Teardown  Teardown
Test Teardown   Test Teardown
Resource        ${RENODEKEYWORDS}

*** Test Cases ***
Should Print Help
    ${x}=  Execute Command     help
           Should Contain      ${x}    Available commands:
```

The test run produces the following result (error):
```
...
[Example Action/test] add-matcher /home/user/example/renode-test-action/src/renode-problem-matcher.json 
| Preparing suites
|
Starting suites
| Running suite on Renode pid 5149 using port 49152: test.robot
^[[74;3R| Suite test.robot failed in 0.02 seconds.
| Cleaning up suites
| Closing Renode pid 5149
| Aggregating all robot results
| Output:  /home/user/example/robot_output.xml 
| Log:     /home/user/example/log.html 
| Report:  /home/user/example/report.html 
| Traceback (most recent call last):
|   File "/tmp/renode-8e8f9c6250ca9858515a05ee94cbd2bfce06a6ce/tests/run_tests.py", line 42, in <module>
|   File "/tmp/renode-8e8f9c6250ca9858515a05ee94cbd2bfce06a6ce/tests/tests_engine.py", line 526, in run
|   File "/tmp/renode-8e8f9c6250ca9858515a05ee94cbd2bfce06a6ce/tests/robot_tests_provider.py", line 642, in cleanup
| FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renode-8e8f9c6250ca9858515a05ee94cbd2bfce06a6ce/tests/../lib/resources/styles/robot.css'
```

By adding the [renode-resources](https://github.com/renode/renode-resources) repository, the missing `robot.css` file is now included, resolving the issue.

## Note

I also replaced `${{ runner.temp }}` with `${{ github.workspace }}` because the files under `/tmp` were being removed by the time the code reached `renode/tests/robot_test_provider.py` at [line 642](https://github.com/renode/renode/blob/master/tests/robot_tests_provider.py#L642).