### PR TITLE
fix: readme: bump renode action version in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: antmicro/renode-test-action@v4
+- uses: antmicro/renode-test-action@v5
   with:
     renode-revision: 'master'
     tests-to-run: 'tests/**/*.robot'


### PR DESCRIPTION
v4 requires gtksharp which is only available on ubuntu 20.04. GitHub deprecated 20.04, and the package is not available in 22 or 24. You need renode-test-action@v5 to work on GitHub Actions now.